### PR TITLE
Fix route setup for PPP links

### DIFF
--- a/scripts/rt_table/mptcp_up
+++ b/scripts/rt_table/mptcp_up
@@ -29,7 +29,7 @@ if [ $DHCP4_IP_ADDRESS ]; then
 else
 	# PPP-interface
 	IPADDR=`echo $IP4_ADDRESS_0 | cut -d \   -f 1 | cut -d / -f 1`
-	ip route add table $DEVICE_IFACE default dev $DEVICE_IFACE scope link
+	ip route add table $DEVICE_IFACE default dev $DEVICE_IP_IFACE scope link
 	ip rule add from $IPADDR table $DEVICE_IFACE
 fi
 


### PR DESCRIPTION
The `mptcp_up` script did not correctly set up the routes for my 4G/LTE USB Modems. I found the following in `/etc/network/if_up_env`:

``` bash
METHOD=NetworkManager
MODE=start
CONNECTION_UUID=ff473cf6-44dc-411e-addf-b598975d097e
LOGICAL=ppp0
DEVICE_IFACE=ttyUSB1
IP4_NAMESERVERS=10.8.11.21 10.8.11.22
PHASE=post-up
ADDRFAM=NetworkManager
IP4_NUM_ADDRESSES=1
VERBOSITY=0
IP4_NUM_ROUTES=0
IP4_ADDRESS_0=10.160.168.121/32 10.64.64.64
DEVICE_IP_IFACE=ppp0
IFACE=ppp0
CONNECTION_ID=Orange
PWD=/
```

The command executed by the script is therefore:

```
ip route add table ttyUSB1 default dev ttyUSB1 scope link
```

which gives me: Cannot find device "ttyUSB1"

This change fixed the problem for me.
It changes said command to:

```
ip route add table ttyUSB1 default dev ppp0 scope link
```
