### PR TITLE
Add dhcpcd hook for Raspberry Pi OS

### DIFF
--- a/scripts/raspberry/README
+++ b/scripts/raspberry/README
@@ -1,0 +1,3 @@
+Raspberry Pi uses dhcpcd by default, so scripts found under /etc/network
+will normally be ignored. Instead, add a hook in /lib/dhcpcd/dhcpcd-hooks
+to autoconfigure network interfaces for MPTCP.

--- a/scripts/raspberry/dhcp-hook-mptcp
+++ b/scripts/raspberry/dhcp-hook-mptcp
@@ -1,0 +1,53 @@
+#!/bin/sh
+#default_gw="192.168.1.1"
+debug_log="/var/log/mptcp-$interface.log"
+rt_tables="/etc/iproute2/rt_tables"
+
+echo "=============================" >$debug_log
+echo "$interface" >>$debug_log
+echo "=============================" >>$debug_log
+printenv >>$debug_log
+echo "--------------" >>$debug_log
+
+# skip non-eth interface (might want to comment out)
+case $interface in eth*) ;; *)
+    ip link set dev $interface multipath off
+    echo "Skipped non-eth $interface" >>$debug_log
+    exit
+esac
+
+echo "Configuring $interface" >>$debug_log
+
+# make sure that table exists before adding rules
+if [ `grep $interface $rt_tables | wc -l` -eq 0 ]; then
+    table_num=`cat $rt_tables | wc -l`
+    echo "$table_num	$interface" >>$rt_tables
+fi
+
+if $if_up; then
+    echo "Configuring MPTCP on $interface" >>$debug_log
+
+    ip link set dev $interface multipath on
+    ip route add table $interface $new_network_number/$new_subnet_mask dev $interface scope link
+    ip route add table $interface default via $new_routers dev $interface
+    ip rule add table $interface from $new_ip_address
+
+    # explicit global gateway (disable all default gw in dhcpcd.conf)
+    if [ $default_gw ]; then
+        if [ $new_routers = $default_gw ]; then
+            ip route add default via $new_routers dev $interface
+            echo "Added $interface as global default gateway" >>$debug_log
+        else
+            ip route del default via $new_routers dev $interface
+            echo "Removed $interface as global default gateway" >>$debug_log
+        fi
+    fi
+else
+    echo "Deconfiguring MPTCP on $interface" >>$debug_log
+
+    ip rule del table $interface
+    ip route flush table $interface
+    ip link set dev $interface multipath off
+fi
+
+echo "Done!" >>$debug_log


### PR DESCRIPTION
The scripts found in [this repository](https://github.com/multipath-tcp/mptcp-scripts/tree/master/scripts/rt_table), as suggested in the official page for [Ubuntu/Debian-based "Automatic "Configuration"](http://multipath-tcp.org/pmwiki.php/Users/ConfigureRouting), don't really fit the default DHCP system (dhcpcd) of recent Raspberry Pi OS releases. Therefore, I tweaked the original scripts a bit to produce a dhcpcd hook for quick MPTCP on the Pi.

I also suggest adding a wiki paragraph about "Raspberry Pi systems" linking to this file, to be copied to `/lib/dhcpcd/dhcpcd-hooks` (with the conventional ordering prefix).